### PR TITLE
Update doNotifyCommit for Jenkins ver. 1.580 and git plugin to 2.2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.466</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>1.580</version><!-- which version of Jenkins is this plugin built against? -->
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>
@@ -16,9 +16,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.jenkinsci.plugins</groupId>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>1.1.24</version>
+      <version>2.2.5</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/org/jenkinsci/plugins/gitorious/GitoriousStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/gitorious/GitoriousStatus.java
@@ -65,14 +65,14 @@ public class GitoriousStatus implements UnprotectedRootAction {
      */
 
     public HttpResponse doNotifyCommit(@QueryParameter String payload)  throws ServletException, IOException {
-    	JSONObject jsonObject = JSONObject.fromObject( payload );
+        JSONObject jsonObject = JSONObject.fromObject( payload );
 
         // HTTP clone access for gitorious is done by adding "git." to the front of the hostname,
         // but the payload URL doesn't come that way. So I added a check in case someone is using HTTP access in jenkins.
         String url2 = jsonObject.getJSONObject("repository").getString("url").replace("://", "://git.");
-        gitStatus.doNotifyCommit(url2 + ".git", null);
+        gitStatus.doNotifyCommit(url2 + ".git", null, null);
 
-    	String url = jsonObject.getJSONObject("repository").getString("url");
-    	return gitStatus.doNotifyCommit(url + ".git", null);
+        String url = jsonObject.getJSONObject("repository").getString("url");
+        return gitStatus.doNotifyCommit(url + ".git", null, null);
     }
 }


### PR DESCRIPTION
Gitorious plugin throws a NoSuchMethodError on "doNotifyCommit( String, String )" on Jenkins ver. 1.580 because the GitStatus class has been updated. This commit calls doNotifyCommit successfully with a null value.

Tested w/ Jenkins ver 1.58 and it successfully fires a build from Gitorious webhooks.
